### PR TITLE
Fix: PHP8 Warning: Undefined array key "deleteConfirm"

### DIFF
--- a/src/Resources/contao/dca/tl_job.php
+++ b/src/Resources/contao/dca/tl_job.php
@@ -71,7 +71,7 @@ $GLOBALS['TL_DCA']['tl_job'] = [
                 'label' => &$GLOBALS['TL_LANG']['tl_job']['delete'],
                 'href' => 'act=delete',
                 'icon' => 'delete.gif',
-                'attributes' => 'onclick="if(!confirm(\''.$GLOBALS['TL_LANG']['MSC']['deleteConfirm'].'\'))return false;Backend.getScrollOffset()"',
+                'attributes' => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? 'confirm delete') . '\'))return false;Backend.getScrollOffset()"',
             ],
             'toggle' => [
                 'label' => &$GLOBALS['TL_LANG']['tl_job']['toggle'],

--- a/src/Resources/contao/dca/tl_job_archive.php
+++ b/src/Resources/contao/dca/tl_job_archive.php
@@ -67,7 +67,7 @@ $GLOBALS['TL_DCA']['tl_job_archive'] = [
                 'label' => &$GLOBALS['TL_LANG']['tl_job_archive']['copy'],
                 'href' => 'act=delete',
                 'icon' => 'delete.gif',
-                'attributes' => 'onclick="if(!confirm(\''.$GLOBALS['TL_LANG']['MSC']['deleteConfirm'].'\'))return false;Backend.getScrollOffset()"',
+                'attributes' => 'onclick="if(!confirm(\'' . ($GLOBALS['TL_LANG']['MSC']['deleteConfirm'] ?? 'confirm delete') . '\'))return false;Backend.getScrollOffset()"',
                 'button_callback' => [\HeimrichHannot\JobBundle\DataContainer\JobArchiveContainer::class, 'deleteArchive'],
             ],
             'show' => [


### PR DESCRIPTION
Return `"confirm delete"` for undefined array keys to prevent php8 warnings in dev mode.